### PR TITLE
Fix #24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,6 @@ dependencies = [
  "terminal_size",
  "wait-timeout",
  "which",
- "wsl",
 ]
 
 [[package]]
@@ -1129,9 +1128,3 @@ checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wsl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ ctrlc = "3.4.1"
 once_cell = "1.18.0"
 directories = "5.0.1"
 which = "5.0.0"
-wsl = "0.1.0"
 crossbeam-queue = "0.3.8"
 num_cpus = "1.16.0"
 


### PR DESCRIPTION
- Fix files with C++ extensions and executable permissions being treated as executable files
- Improve error handling when an invalid executable is provided to Toster